### PR TITLE
Make 'get_url' functions compatible with IOS

### DIFF
--- a/src/otp.lua
+++ b/src/otp.lua
@@ -130,7 +130,7 @@ function totpmt:verify(code, accepted_deviation, for_time)
 end
 
 function totpmt:get_url(issuer, account, issuer_uuid)
-  local key, issuer, account = url_encode(bxx.to_base32(self.key)), url_encode(issuer), url_encode(account)
+  local key, issuer, account = url_encode((bxx.to_base32(self.key):gsub('=', ''))), url_encode(issuer), url_encode(account)
   local issuer_uuid = issuer_uuid and url_encode(issuer_uuid) or issuer
   return table.concat{
     "otpauth://totp/",
@@ -196,7 +196,7 @@ function hotpmt:verify(code, accepted_deviation)
 end
 
 function hotpmt:get_url(issuer, account, issuer_uuid)
-  local key, issuer, account = url_encode(bxx.to_base32(self.key)), url_encode(issuer), url_encode(account)
+  local key, issuer, account = url_encode((bxx.to_base32(self.key):gsub('=', ''))), url_encode(issuer), url_encode(account)
   local issuer_uuid = issuer_uuid and url_encode(issuer_uuid) or issuer
   return table.concat{
     "otpauth://hotp/",


### PR DESCRIPTION
Unfortunately IOS can not handle the trailing '=' character(s) when
sharing the base32-encoded otp-secret. We can simply remove the trailing
'=' characters from the encoded secret in the URL to fix this.

Tested with 'Authy', 'Google Authenticator' and 'Free OTP' on IOS and
Android.